### PR TITLE
PLANET-6039: Replace chevron icon

### DIFF
--- a/img/chevron-down.svg
+++ b/img/chevron-down.svg
@@ -1,9 +1,36 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="16px" height="9px" viewBox="0 0 16 9" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>chevron</title>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Passive-drop-down" transform="translate(-368.000000, -20.000000)" fill="#6F7376">
-            <path d="M372.26035,17.2745874 C372.607482,16.9084709 373.170296,16.9084709 373.517428,17.2745874 L373.517428,17.2745874 L379.73965,23.8370874 L379.73965,23.8370874 C380.086783,24.2032039 380.086783,24.7967961 379.73965,25.1629126 L373.517428,31.7254126 C373.170296,32.0915291 372.607482,32.0915291 372.26035,31.7254126 C371.913217,31.3592961 371.913217,30.7657039 372.26035,30.3995874 L377.854,24.5 L372.26035,18.6004126 C371.942145,18.2648058 371.915627,17.7380563 372.180798,17.3705923 Z" id="chevron" transform="translate(376.000000, 24.500000) rotate(90.000000) translate(-376.000000, -24.500000) "></path>
-        </g>
-    </g>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 407.437 407.437" style="enable-background:new 0 0 407.437 407.437;" xml:space="preserve">
+<polygon points="386.258,91.567 203.718,273.512 21.179,91.567 0,112.815 203.718,315.87 407.437,112.815 "/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
 </svg>


### PR DESCRIPTION
Ref: https://jira.greenpeace.org/browse/PLANET-6039

See the [Rich diff](https://upload.wikimedia.org/wikipedia/commons/8/86/Chevron_Logo.svg) to view the image.

Also, remember to check the date.